### PR TITLE
Change to populate mutable struct

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,8 @@
 extern crate swapi;
 
 fn main() {
-    swapi::types::species::query_species("3");
+    let mut planet_resp: swapi::types::planets::Planet = Default::default();
+    println!("{:#?}", planet_resp);
+    swapi::query::query<swapi::types::planets::Planet>("/planets/1", &mut planet_resp);
+    println!("{:#?}", planet_resp);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 extern crate swapi;
 
 fn main() {
-    let mut planet_resp: swapi::types::planets::Planet = Default::default();
+    let mut planet_resp: swapi::types::species::Species = Default::default();
     println!("{:#?}", planet_resp);
-    swapi::query::query<swapi::types::planets::Planet>("/planets/1", &mut planet_resp);
+    swapi::types::species::query_species("6", &mut planet_resp);
     println!("{:#?}", planet_resp);
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -10,6 +10,8 @@ pub enum StarWarsType {
     Planets(super::planets::Planet),
 }
 
+
+
 pub fn api_query(endpoint: &str) -> Result<reqwest::Response, reqwest::Error> {
     // Base URL for all API requests
     // endpoint is concatenated onto base_url
@@ -26,4 +28,18 @@ pub fn api_query(endpoint: &str) -> Result<reqwest::Response, reqwest::Error> {
     };
 
     query_results
+}
+
+pub fn query<'de, T>(endpoint: &str, _type_buf: &mut T) 
+    where T: serde::de::Deserialize<'de> + Default + Clone {
+    let results = api_query(endpoint);
+    match results {
+        Ok(mut r) => {
+            *_type_buf = match r.json::<T>() {
+                Ok(v) => v,
+                Err(e) => panic!("Fatal Decoding Error {:#?}", e)
+            }.clone();
+        },
+        Err(e) => panic!("{:#?}", e)
+    }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -30,6 +30,26 @@ pub fn api_query(endpoint: &str) -> Result<reqwest::Response, reqwest::Error> {
     query_results
 }
 
+/* 
+ * serde_derive & generics
+ *
+ * Generic query method, not (fully) functioning due to the unique implemententations
+ * generated for each struct when Deserialize is derived (serde_derive). 
+ * 
+ * When a struct derives Deserialize, serde_derive generates a unique implementation 
+ * for that struct, its implementation is generated in a module with this pattern:
+ *  CURR_MOD::_IMPL_DESERIALIZE_FOR_StructName::_serde::Deserialize<'de>
+ * 
+ * Rust doesnt accept the uniquly generated implementations as satisfying the
+ * where T: serde::Deserialize type requirement.
+ *
+ * I believe it could be worked around by manually implementing Deserialize, or by
+ * taking a look at the macros serde provides to see if theres a way to
+ * generate Deserialize implementations that can satisfy type requirements.
+ *
+ * Future release candidate
+ *
+ *
 pub fn query<'de, T>(endpoint: &str, _type_buf: &mut T) 
     where T: serde::de::Deserialize<'de> + Default + Clone {
     let results = api_query(endpoint);
@@ -43,3 +63,4 @@ pub fn query<'de, T>(endpoint: &str, _type_buf: &mut T)
         Err(e) => panic!("{:#?}", e)
     }
 }
+*/

--- a/src/types/films.rs
+++ b/src/types/films.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, Clone)]
 pub struct Film {
     title: String,
     episode_id: i32,
@@ -16,13 +16,19 @@ pub struct Film {
     edited: String,
 }
 
-pub fn query_film(title: &str) {
+pub fn query_film(title: &str, _film_buf: &mut Film) { 
     let base_url: String = "/films/".to_owned();
     let film_url: &str = &(base_url + &title);
 
     let results = super::query::api_query(film_url);
     match results {
-        Ok(mut r) => println!("{:#?}", r.json::<Film>()),
-        Err(e) => println!("{:#?}", e),
+        Ok(mut r) => {
+            *_film_buf = match r.json::<Film>() {
+                Ok(v) => v,
+                Err(e) => panic!("Decoding error {:#?}", e)
+            }.clone();
+
+        },
+        Err(e) => panic!("{:#?}", e),
     }
 }

--- a/src/types/people.rs
+++ b/src/types/people.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, Clone)]
 pub struct People {
     name: String,
     birth_year: String,
@@ -18,14 +18,20 @@ pub struct People {
     edited: String,
 }
 
-pub fn query_people(people_num: &str) {
+pub fn query_people(people_num: &str, _people_buf: &mut People) {
     // Base URL for a people request
     let base_url: String = "/people/".to_owned();
     let people_url: &str = &(base_url + &people_num);
 
     let results = super::query::api_query(people_url);
     match results {
-        Ok(mut r) => println!("{:#?}", r.json::<People>()),
-        Err(e) => println!("{:#?}", e),
+        Ok(mut r) => {
+            *_people_buf = match r.json::<People>() {
+                Ok(v) => v,
+                Err(e) => panic!("Decoding error {:#?}", e)
+            }.clone();
+
+        },
+        Err(e) => panic!("{:#?}", e),
     }
 }

--- a/src/types/planets.rs
+++ b/src/types/planets.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, Clone)]
 pub struct Planet {
     climate: String,
     created: String,
@@ -16,14 +16,19 @@ pub struct Planet {
     url: String,
 }
 
-pub fn query_planet(planet_num: &str) {
+pub fn query_planet(planet_num: &str, _planet_buf: &mut Planet) {
     // Base URL for a planet request
     let base_url: String = "/planets/".to_owned();
     let planet_url: &str = &(base_url + &planet_num);
-
     let results = super::query::api_query(planet_url);
     match results {
-        Ok(mut r) => println!("{:#?}", r.json::<Planet>()),
-        Err(e) => println!("{:#?}", e),
+        Ok(mut r) => {
+            *_planet_buf = match r.json::<Planet>() {
+                Ok(v) => v,
+                Err(e) => panic!("Decoding error {:#?}", e)
+            }.clone();
+
+        },
+        Err(e) => panic!("{:#?}", e),
     }
 }

--- a/src/types/species.rs
+++ b/src/types/species.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, Clone)]
 pub struct Species {
     average_height: String,
     average_lifespan: String,
@@ -17,14 +17,20 @@ pub struct Species {
     url: String,
 }
 
-pub fn query_species(species_num: &str) {
+pub fn query_species(species_num: &str, _species_buf: &mut Species) {
     // Base URL for a species request
     let base_url: String = "/species/".to_owned();
     let species_url: &str = &(base_url + &species_num);
 
     let results = super::query::api_query(species_url);
     match results {
-        Ok(mut r) => println!("{:#?}", r.json::<Species>()),
-        Err(e) => println!("{:#?}", e),
+        Ok(mut r) => {
+            *_species_buf = match r.json::<Species>() {
+                Ok(v) => v,
+                Err(e) => panic!("Decoding error {:#?}", e)
+            }.clone();
+
+        },
+        Err(e) => panic!("{:#?}", e),
     }
 }

--- a/src/types/starships.rs
+++ b/src/types/starships.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, Clone)]
 pub struct Starships {
     name: String,
     model: String,
@@ -20,14 +20,20 @@ pub struct Starships {
     edited: String,
 }
 
-pub fn query_starships(starships_num: &str) {
+pub fn query_starships(starships_num: &str, _starships_buf: &mut Starships) {
     // Base URL for a starships request
     let base_url: String = "/starships/".to_owned();
     let starships_url: &str = &(base_url + &starships_num);
 
     let results = super::query::api_query(starships_url);
     match results {
-        Ok(mut r) => println!("{:#?}", r.json::<Starships>()),
-        Err(e) => println!("{:#?}", e),
+        Ok(mut r) => {
+            *_starships_buf = match r.json::<Starships>() {
+                Ok(v) => v,
+                Err(e) => panic!("Decoding error {:#?}", e)
+            }.clone();
+
+        },
+        Err(e) => panic!("{:#?}", e),
     }
 }

--- a/src/types/vehicles.rs
+++ b/src/types/vehicles.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, Clone)]
 pub struct Vehicles {
     cargo_capacity: String,
     consumables: String,
@@ -17,15 +17,20 @@ pub struct Vehicles {
     url: String,
     vehicle_class: String,
 }
-
-pub fn query_vehicles(vehicles_num: &str) {
+/*
+pub fn query_vehicles(vehicles_num: &str, _vehicles_buf: &mut Vehicles) {
     // Base URL for a vehicles request
     let base_url: String = "/vehicles/".to_owned();
     let vehicles_url: &str = &(base_url + &vehicles_num);
 
     let results = super::query::api_query(vehicles_url);
     match results {
-        Ok(mut r) => println!("{:#?}", r.json::<Vehicles>()),
+        Ok(mut r) => {
+            *_vehicles_buf = match r.json::<Planet>() {
+                Ok(v) => v,
+                Err(e) => panic!("")
+            }.clone();
+        },
         Err(e) => println!("{:#?}", e),
     }
-}
+}*/

--- a/src/types/vehicles.rs
+++ b/src/types/vehicles.rs
@@ -17,7 +17,7 @@ pub struct Vehicles {
     url: String,
     vehicle_class: String,
 }
-/*
+
 pub fn query_vehicles(vehicles_num: &str, _vehicles_buf: &mut Vehicles) {
     // Base URL for a vehicles request
     let base_url: String = "/vehicles/".to_owned();
@@ -26,11 +26,11 @@ pub fn query_vehicles(vehicles_num: &str, _vehicles_buf: &mut Vehicles) {
     let results = super::query::api_query(vehicles_url);
     match results {
         Ok(mut r) => {
-            *_vehicles_buf = match r.json::<Planet>() {
+            *_vehicles_buf = match r.json::<Vehicles>() {
                 Ok(v) => v,
                 Err(e) => panic!("")
             }.clone();
         },
         Err(e) => println!("{:#?}", e),
     }
-}*/
+}


### PR DESCRIPTION
This pull request implements the following changes:

- Query methods (query_type) now require a mutable reference to a struct. It will have the contents of the response cloned into it.