### PR TITLE
Verbiage update

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,14 +43,17 @@ pub fn query_film(title: &str, _film_buf: &mut Film) {
     }
 }
 
-pub fn query_people(people_num: &str, _people_buf: &mut People) {
+pub fn query_people(people_num: &str) {
     // Base URL for a people request
     let base_url: String = "/people/".to_owned();
     let people_url: &str = &(base_url + &people_num);
+
     let results = api_query(people_url);
+    let mut _people_buf: self::types::Person = Default::default();
+
     match results {
         Ok(mut r) => {
-            *_people_buf = match r.json::<People>() {
+            _people_buf = match r.json::<Person>() {
                 Ok(v) => v,
                 Err(e) => panic!("Decoding error {:#?}", e),
             }
@@ -60,14 +63,17 @@ pub fn query_people(people_num: &str, _people_buf: &mut People) {
     }
 }
 
-pub fn query_planet(planet_num: &str, _planet_buf: &mut Planet) {
+pub fn query_planet(planet_num: &str) {
     // Base URL for a planet request
     let base_url: String = "/planets/".to_owned();
     let planet_url: &str = &(base_url + &planet_num);
+
     let results = api_query(planet_url);
+    let mut _planet_buf: self::types::Planet = Default::default();
+
     match results {
         Ok(mut r) => {
-            *_planet_buf = match r.json::<Planet>() {
+            _planet_buf = match r.json::<Planet>() {
                 Ok(v) => v,
                 Err(e) => panic!("Decoding error {:#?}", e),
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,110 +26,147 @@ pub fn api_query(endpoint: &str) -> Result<reqwest::Response, reqwest::Error> {
     query_results
 }
 
-pub fn query_film(title: &str, _film_buf: &mut Film) {
+/// Query films details given the film number.
+///
+/// # Examples
+///
+/// ```
+/// swapi::query_film("1");
+/// ```
+pub fn query_film(title: &str) {
     let base_url: String = "/films/".to_owned();
     let film_url: &str = &(base_url + &title);
 
     let results = api_query(film_url);
     match results {
         Ok(mut r) => {
-            *_film_buf = match r.json::<Film>() {
-                Ok(v) => v,
+            match r.json::<Film>() {
+                Ok(v) => println!("{:#?}", v),
                 Err(e) => panic!("Decoding error {:#?}", e),
-            }
-            .clone();
+            };
         }
         Err(e) => panic!("{:#?}", e),
     }
 }
 
-pub fn query_people(people_num: &str) {
-    // Base URL for a people request
+/// Query a characters details given the characters number.
+///
+/// # Examples
+///
+/// ```
+/// swapi::query_person("1");
+/// ```
+pub fn query_person(people_num: &str) {
     let base_url: String = "/people/".to_owned();
-    let people_url: &str = &(base_url + &people_num);
+    let person_url: &str = &(base_url + &people_num);
 
-    let results = api_query(people_url);
-    let mut _people_buf: self::types::Person = Default::default();
+    let results = api_query(person_url);
+    // let mut _people_buf: self::types::Person = Default::default();
 
     match results {
-        Ok(mut r) => {
-            _people_buf = match r.json::<Person>() {
-                Ok(v) => v,
-                Err(e) => panic!("Decoding error {:#?}", e),
-            }
-            .clone();
-        }
+        Ok(mut r) => match r.json::<Person>() {
+            Ok(v) => println!("{:#?}", v),
+            Err(e) => panic!("Decoding error {:#?}", e),
+        },
         Err(e) => panic!("{:#?}", e),
     }
 }
 
+/// Query a planets details given the planet number.
+///
+/// # Examples
+///
+/// ```
+/// swapi::query_planet("1");
+/// ```
 pub fn query_planet(planet_num: &str) {
-    // Base URL for a planet request
     let base_url: String = "/planets/".to_owned();
     let planet_url: &str = &(base_url + &planet_num);
 
     let results = api_query(planet_url);
-    let mut _planet_buf: self::types::Planet = Default::default();
+    // let mut _planet_buf: self::types::Planet = Default::default();
 
     match results {
         Ok(mut r) => {
-            _planet_buf = match r.json::<Planet>() {
-                Ok(v) => v,
+            match r.json::<Planet>() {
+                Ok(v) => println!("{:#?}", v),
                 Err(e) => panic!("Decoding error {:#?}", e),
-            }
-            .clone();
+            };
         }
         Err(e) => panic!("{:#?}", e),
     }
 }
 
-pub fn query_species(species_num: &str, _species_buf: &mut Species) {
-    // Base URL for a species request
+/// Query a species details given the species number.
+///
+/// # Examples
+///
+/// ```
+/// swapi::query_species("1");
+/// ```
+pub fn query_species(species_num: &str) {
     let base_url: String = "/species/".to_owned();
     let species_url: &str = &(base_url + &species_num);
+
     let results = api_query(species_url);
+    // let mut _species_buf: self::types::Planet = Default::default();
+
     match results {
         Ok(mut r) => {
-            *_species_buf = match r.json::<Species>() {
-                Ok(v) => v,
+            match r.json::<Species>() {
+                Ok(v) => println!("{:#?}", v),
                 Err(e) => panic!("Decoding error {:#?}", e),
-            }
-            .clone();
+            };
         }
         Err(e) => panic!("{:#?}", e),
     }
 }
 
-pub fn query_starships(starships_num: &str, _starships_buf: &mut Starships) {
-    // Base URL for a starships request
+/// Query a starships details given the starship number.
+///
+/// # Examples
+///
+/// ```
+/// swapi::query_starship("1");
+/// ```
+pub fn query_starship(starship_num: &str) {
     let base_url: String = "/starships/".to_owned();
-    let starships_url: &str = &(base_url + &starships_num);
-    let results = api_query(starships_url);
+    let starship_url: &str = &(base_url + &starship_num);
+
+    let results = api_query(starship_url);
+    // let mut _starship_buf: self::types::Planet = Default::default();
+
     match results {
         Ok(mut r) => {
-            *_starships_buf = match r.json::<Starships>() {
-                Ok(v) => v,
+            match r.json::<Starship>() {
+                Ok(v) => println!("{:#?}", v),
                 Err(e) => panic!("Decoding error {:#?}", e),
-            }
-            .clone();
+            };
         }
         Err(e) => panic!("{:#?}", e),
     }
 }
 
-pub fn query_vehicles(vehicles_num: &str, _vehicles_buf: &mut types::Vehicles) {
-    // Base URL for a vehicles request
+/// Query a vehicles details given the vehicle number.
+///
+/// # Examples
+///
+/// ```
+/// swapi::query_starship("1");
+/// ```
+pub fn query_vehicle(vehicle_num: &str) {
     let base_url: String = "/vehicles/".to_owned();
-    let vehicles_url: &str = &(base_url + &vehicles_num);
+    let vehicle_url: &str = &(base_url + &vehicle_num);
 
-    let results = api_query(vehicles_url);
+    let results = api_query(vehicle_url);
+    // let mut _starship_buf: self::types::Planet = Default::default();
+
     match results {
         Ok(mut r) => {
-            *_vehicles_buf = match r.json::<types::Vehicles>() {
-                Ok(v) => v,
+            match r.json::<types::Vehicle>() {
+                Ok(v) => println!("{:#?}", v),
                 Err(e) => panic!("Decoding error {:#?}", e),
-            }
-            .clone();
+            };
         }
         Err(e) => println!("{:#?}", e),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 extern crate swapi;
 
 fn main() {
-    let mut planet_resp: swapi::types::Species = Default::default();
-    swapi::query_species("6", &mut planet_resp);
+    swapi::query_species("6");
     println!("{:#?}", planet_resp);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 extern crate swapi;
 
 fn main() {
-    swapi::query_species("6");
-    println!("{:#?}", planet_resp);
+    swapi::query_species("2");
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,14 +1,14 @@
 // Possible Star Wars data types
 // that a GET request can return
-#[derive(Debug, Deserialize)]
-pub enum StarWarsType {
-    People(People),
-    Films(Film),
-    Starships(Starships),
-    Vehicles(Vehicles),
-    Species(Species),
-    Planets(Planet),
-}
+// #[derive(Debug, Deserialize)]
+// pub enum StarWarsType {
+//     People(Person),
+//     Films(Film),
+//     Starships(Starship),
+//     Vehicles(Vehicle),
+//     Species(Species),
+//     Planets(Planet),
+// }
 
 #[derive(Debug, Deserialize, Default, Clone)]
 pub struct Film {
@@ -17,7 +17,7 @@ pub struct Film {
     opening_crawl: String,
     director: String,
     producer: String,
-    release_date: String, // ISO 8601 of release date
+    release_date: String,
     species: Vec<String>,
     starships: Vec<String>,
     vehicles: Vec<String>,
@@ -29,7 +29,7 @@ pub struct Film {
 }
 
 #[derive(Debug, Deserialize, Default, Clone)]
-pub struct People {
+pub struct Person {
     name: String,
     birth_year: String,
     eye_color: String,
@@ -86,7 +86,7 @@ pub struct Species {
 }
 
 #[derive(Debug, Deserialize, Default, Clone)]
-pub struct Starships {
+pub struct Starship {
     name: String,
     model: String,
     starship_class: String,
@@ -108,7 +108,7 @@ pub struct Starships {
 }
 
 #[derive(Debug, Deserialize, Default, Clone)]
-pub struct Vehicles {
+pub struct Vehicle {
     cargo_capacity: String,
     consumables: String,
     cost_in_credits: String,

--- a/src/types.rs
+++ b/src/types.rs
@@ -76,7 +76,7 @@ pub struct Species {
     edited: String,
     eye_colors: String,
     hair_colors: String,
-    homeworld: String,
+    homeworld: Option<String>,
     language: String,
     name: String,
     people: Vec<String>,


### PR DESCRIPTION
This PR changes the verbiage for queries to make it clear that each function is only querying a single result. I also simplified the API so the end user does not have to pass in a struct to generate the query results. Currently the query will only print the results to the console so the struct buffers are commented out until we want to start returning them again. 

This also closes #10  